### PR TITLE
Feature actas

### DIFF
--- a/src/Utils/FetchWithToken.ts
+++ b/src/Utils/FetchWithToken.ts
@@ -1,0 +1,31 @@
+import { useAuthStore } from "../store/auth";
+
+// Obtener token de autenticación almacenado en localStorage
+export const getToken = (): string | null => {
+    const authData = JSON.parse(localStorage.getItem('auth') || '{}');
+    return authData.token || null;
+  };
+
+// Realizar una petición fetch con el token de autenticación
+export const fetchWithAuth = async (url: string, options: RequestInit): Promise<Response> => {
+  const authStore = useAuthStore(); // Obtiene el store de autenticación
+  const token = authStore.token || getToken(); // Obtiene el token desde el store o localStorage
+  
+  if (token) {
+    options.headers = {
+      ...options.headers,
+      'Authorization': `Bearer ${token}`,
+    };
+  }
+
+  const response = await fetch(url, options);
+
+  // Verificar si la respuesta tiene código 403
+  if (response.status === 403) {
+    // Llama al método logout para limpiar el token
+    authStore.logout();
+    console.error('Acceso denegado: token inválido o expirado. Se ha cerrado la sesión.');
+  }
+
+  return response;
+};

--- a/src/modules/acts/ActsList.vue
+++ b/src/modules/acts/ActsList.vue
@@ -18,14 +18,14 @@
           </tr>
         </thead>
         <tbody>
-          <tr v-for="acta in actas" :key="acta.NUM_ACTAS">
-            <td>{{ acta.NUM_ACTAS }}</td>
-            <td>{{ acta.ESTADO }}</td>
-            <td>{{ acta.SESION_IDSESION }}</td>
+          <tr v-for="acta in actas" :key="acta.numeroActa">
+            <td>{{ acta.numeroActa }}</td>
+            <td>{{ acta.estado }}</td>
+            <td></td>
             <td class="flex gap-2">
-              <router-link :to="`/acts/${acta.NUM_ACTAS}`" class="btn btn-info btn-sm">Ver</router-link>
-              <router-link :to="`/acts/edit/${acta.NUM_ACTAS}`" class="btn btn-warning btn-sm">Editar</router-link>
-              <button @click="showConfirmModal(acta.NUM_ACTAS)" class="btn btn-error btn-sm">Eliminar</button>
+              <router-link :to="`/acts/${acta.numeroActa}`" class="btn btn-info btn-sm">Ver</router-link>
+              <router-link :to="`/acts/edit/${acta.numeroActa}`" class="btn btn-warning btn-sm">Editar</router-link>
+              <button @click="showConfirmModal(acta.numeroActa)" class="btn btn-error btn-sm">Eliminar</button>
             </td>
           </tr>
         </tbody>
@@ -45,17 +45,13 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue';
+import { ref, computed, onMounted } from 'vue';
 import { useRoute } from 'vue-router';
 import ConfirmModal from '../../components/ConfirmModal.vue';
+import { Acta, getActas } from '../../services/actaService';
 
-// Lista de actas simuladas
-const actas = ref([
-  { NUM_ACTAS: 101, ESTADO: 'FIRMADA', SESION_IDSESION: 1 },
-  { NUM_ACTAS: 102, ESTADO: 'EN PROCESO', SESION_IDSESION: 2 },
-  { NUM_ACTAS: 103, ESTADO: 'FIRMADA', SESION_IDSESION: 3 }
-]);
 
+const actas = ref<Acta[]>([]);
 const isModalVisible = ref(false);
 const actaIdToDelete = ref<number | null>(null);
 
@@ -65,6 +61,20 @@ const isChildRouteActive = computed(() => {
   return route.matched.some(r => r.path.includes('/acts/create') || r.path.includes('/acts/edit') || r.path.includes('/acts/'));
 });
 
+// Cargar las actas desde el servicio
+const loadActas = async () => {
+  try {
+    const response = await getActas();
+    actas.value = response.data || [];
+  } catch (error) {
+    console.error('Error al cargar actas:', error);
+  }
+};
+
+onMounted(() => {
+  loadActas();
+});
+
 const showConfirmModal = (id: number) => {
   actaIdToDelete.value = id;
   isModalVisible.value = true;
@@ -72,7 +82,7 @@ const showConfirmModal = (id: number) => {
 
 const confirmDelete = () => {
   if (actaIdToDelete.value !== null) {
-    const index = actas.value.findIndex(acta => acta.NUM_ACTAS === actaIdToDelete.value);
+    const index = actas.value.findIndex((acta: Acta) => acta.numeroActa === actaIdToDelete.value);
     if (index !== -1) {
       actas.value.splice(index, 1); // Eliminar acta de la lista
     }
@@ -86,9 +96,3 @@ const cancelDelete = () => {
   actaIdToDelete.value = null;
 };
 </script>
-
-<style scoped>
-.table {
-  margin-top: 20px;
-}
-</style>

--- a/src/modules/sessions/SessionsForm.vue
+++ b/src/modules/sessions/SessionsForm.vue
@@ -212,7 +212,6 @@ import {
   updateSession,
   getSessionById,
   addAsistenciaMiembros,
-  addActas,
   definirContenidoSesion,
   Session,
   addAsistenciaInvitados
@@ -220,6 +219,7 @@ import {
 import InvitadosModal from '../../components/modals/InvitadosModal.vue';
 import MiembrosModal from '../../components/modals/MiembrosModal.vue';
 import { ApiResponse } from '../../Utils/Interfaces/AuthInterface';
+import { addActas } from '../../services/actaService';
 
 const newSession = ref<Session>({
   lugar: '',

--- a/src/modules/sessions/SessionsForm.vue
+++ b/src/modules/sessions/SessionsForm.vue
@@ -122,7 +122,6 @@
       <div class="flex space-x-4" v-if="isEditing && !isViewing">
         <button type="button" class="btn btn-primary" @click="showInvitadosModal = true">Agregar Invitados</button>
         <button type="button" class="btn btn-primary" @click="showMiembrosModal = true">Agregar Miembros</button>
-        <button type="button" class="btn btn-secondary" @click="addActa">Agregar Acta</button>
       </div>
 
       <!-- Tabla de Invitados -->
@@ -355,15 +354,5 @@ const addMiembro = async (miembro: any) => {
   }
 };
 
-// Función para agregar un acta a la sesión
-const addActa = async () => {
-  if (isViewing.value || !sessionId.value) return;
-  try {
-    const acta = { estado: 'Pendiente' }; // o establece el estado según corresponda
-    await addActas(sessionId.value, acta);
-    console.log('Acta agregada exitosamente');
-  } catch (error) {
-    console.error('Error al agregar acta:', error);
-  }
-};
+
 </script>

--- a/src/services/actaService.ts
+++ b/src/services/actaService.ts
@@ -1,0 +1,49 @@
+import { fetchWithAuth } from "../Utils/FetchWithToken";
+import { ApiResponse } from "../Utils/Interfaces/AuthInterface";
+
+export const API_ACTAS_URL = `${import.meta.env.VITE_API_URL}/actas`;
+
+export interface Acta {
+    idActa: number;
+    numeroActa: number;
+    estado: string;
+  }
+
+
+// Consultar todas las actas
+export const getActas = async (): Promise<ApiResponse<Acta[]>> => {
+  try {
+    const response = await fetchWithAuth(API_ACTAS_URL, { method: 'GET' });
+    if (!response.ok) throw new Error('Error al obtener las actas');
+    return await response.json() as ApiResponse<Acta[]>;
+  } catch (error) {
+    console.error('Error al obtener las actas:', error);
+    throw error;
+  }
+};
+
+
+// Función para agregar actas a una sesión
+export const addActas = async (idSesion: number, acta: any): Promise<ApiResponse<any>> => {
+    try {
+      const response = await fetchWithAuth(`${API_ACTAS_URL}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          estado: acta.estado,
+          sesion: { idSesion },
+        }),
+      });
+  
+      if (!response.ok) {
+        const errorData = await response.json();
+        const backendMessage = errorData.message || 'Error al agregar el acta';
+        throw new Error(backendMessage);
+      }
+  
+      return await response.json() as ApiResponse<any>;
+    } catch (error) {
+      console.error('Error al agregar el acta:', error);
+      throw error;
+    }
+  };

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia';
 import { Usuario } from '../Utils/Interfaces/UsuarioInterface';
 import { LoginData, LoginResponse } from '../Utils/Interfaces/AuthInterface';
 import { login as loginService, isTokenValid } from '../services/authService';
+import router from '../router';
 
 // Define la interfaz del estado de autenticación
 export interface AuthState {
@@ -50,6 +51,7 @@ export const useAuthStore = defineStore("auth", {
 
       // Eliminar el token de localStorage
       localStorage.removeItem('auth');
+      router.push('/login');
     },
 
     loadToken(): void {


### PR DESCRIPTION
This pull request includes several changes to improve the authentication handling, acta management, and session management in the application. The most important changes include the introduction of a new utility for fetching with authentication, refactoring of acta-related components and services, and updates to session creation to include acta creation.

### Authentication Handling:
* Added `fetchWithAuth` and `getToken` utilities to handle authenticated fetch requests and token retrieval. (`src/Utils/FetchWithToken.ts`)
* Updated `useAuthStore` to redirect to the login page upon logout. (`src/store/auth.ts`)

### Acta Management:
* Refactored `ActsList.vue` to load actas from the service and updated the template to use new acta properties. (`src/modules/acts/ActsList.vue`) [[1]](diffhunk://#diff-c60e9a2302bffa07cf90f3b62278a5a04a620e89c2be9c0ab344403b7860d075L21-R28) [[2]](diffhunk://#diff-c60e9a2302bffa07cf90f3b62278a5a04a620e89c2be9c0ab344403b7860d075L48-R54) [[3]](diffhunk://#diff-c60e9a2302bffa07cf90f3b62278a5a04a620e89c2be9c0ab344403b7860d075R64-R85) [[4]](diffhunk://#diff-c60e9a2302bffa07cf90f3b62278a5a04a620e89c2be9c0ab344403b7860d075L89-L94)
* Created `actaService.ts` to handle acta-related API calls, including fetching and adding actas. (`src/services/actaService.ts`)

### Session Management:
* Removed redundant acta-related code from `SessionsForm.vue` and updated it to use `actaService` for acta creation. (`src/modules/sessions/SessionsForm.vue`) [[1]](diffhunk://#diff-ba38d65e71a6ce620da7783c516b9b64180c82a1dffd2e4bdd5a2d956974b0d8L125) [[2]](diffhunk://#diff-ba38d65e71a6ce620da7783c516b9b64180c82a1dffd2e4bdd5a2d956974b0d8L215-R221) [[3]](diffhunk://#diff-ba38d65e71a6ce620da7783c516b9b64180c82a1dffd2e4bdd5a2d956974b0d8L358-R357)
* Updated `SessionServices.ts` to create an acta when a session is created. (`src/services/SessionServices.ts`) [[1]](diffhunk://#diff-7561bdf4bc50b04c5916652d1675a5639797a64daed444e499f122ced2af69cdR1-R6) [[2]](diffhunk://#diff-7561bdf4bc50b04c5916652d1675a5639797a64daed444e499f122ced2af69cdL20-L36) [[3]](diffhunk://#diff-7561bdf4bc50b04c5916652d1675a5639797a64daed444e499f122ced2af69cdL48-R34) [[4]](diffhunk://#diff-7561bdf4bc50b04c5916652d1675a5639797a64daed444e499f122ced2af69cdL64-R67) [[5]](diffhunk://#diff-7561bdf4bc50b04c5916652d1675a5639797a64daed444e499f122ced2af69cdL131-L154)