### PR TITLE
Update allowed roles for CRUD routes to enhance access control

### DIFF
--- a/src/router/protectedRoutes.ts
+++ b/src/router/protectedRoutes.ts
@@ -113,18 +113,18 @@ function createCrudRoutes(configs: CrudRouteConfig[]): RouteRecordRaw[] {
 
 
 const crudConfigs: CrudRouteConfig[] = [
-  { basePath: 'tasks', listComponent: TasksList, formComponent: TaskAssignmentsForm, RouteName: 'Tareas', allowedRoles: ['ADMINISTRADOR', 'MODERADOR'] },
-  { basePath: 'requests', listComponent: RequestsList, formComponent: RequestsForm, EditComponent: SoliEdit, RouteName: 'Solicitudes', allowedRoles: ['ADMINISTRADOR', 'INTEGRANTECOMITE'] },
-  { basePath: 'sessions', listComponent: SessionsList, formComponent: SessionsForm, RouteName: 'Sesiones', allowedRoles: ['SECRETARIO', 'ADMINISTRADOR'] },
-  { basePath: 'members', listComponent: MembersList, formComponent: MembersForm, RouteName: 'Miembros', allowedRoles: ['ADMINISTRADOR'] },
-  { basePath: 'applicants', listComponent: ApplicantsList, formComponent: ApplicantsForm, RouteName: 'Solicitantes', allowedRoles: ['SECRETARIO'] },
+  { basePath: 'tasks', listComponent: TasksList, formComponent: TaskAssignmentsForm, RouteName: 'Tareas', allowedRoles: ['ESTUDIANTE','ADMINISTRADOR'] },
+  { basePath: 'requests', listComponent: RequestsList, formComponent: RequestsForm, EditComponent: SoliEdit, RouteName: 'Solicitudes', allowedRoles: ['DOCENTE','INVITADO','ESTUDIANTE','ADMINISTRADOR', 'INTEGRANTECOMITE'] },
+  { basePath: 'sessions', listComponent: SessionsList, formComponent: SessionsForm, RouteName: 'Sesiones', allowedRoles: ['DOCENTE','MODERADOR','INVITADO','ESTUDIANTE','SECRETARIO', 'ADMINISTRADOR'] },
+  { basePath: 'members', listComponent: MembersList, formComponent: MembersForm, RouteName: 'Miembros', allowedRoles: ['MODERADOR','ADMINISTRADOR'] },
+  { basePath: 'applicants', listComponent: ApplicantsList, formComponent: ApplicantsForm, RouteName: 'Solicitantes', allowedRoles: ['SECRETARIO','ADMINISTRADOR'] },
   { basePath: 'guests', listComponent: GuestsList, formComponent: GuestsCreate, RouteName: 'Invitados', allowedRoles: ['MODERADOR', 'ADMINISTRADOR'] },
-  { basePath: 'propositions', listComponent: PropositionsList, formComponent: PropositionsCreate, RouteName: 'Proposiciones', allowedRoles: ['INTEGRANTECOMITE'] },
-  { basePath: 'acts', listComponent: ActsList, formComponent: null, detailComponent: ActsDetail, RouteName: 'Actas', allowedRoles: ['SECRETARIO', 'ADMINISTRADOR'] },
+  { basePath: 'propositions', listComponent: PropositionsList, formComponent: PropositionsCreate, RouteName: 'Proposiciones', allowedRoles: ['DOCENTE','INTEGRANTECOMITE','ADMINISTRADOR'] },
+  { basePath: 'acts', listComponent: ActsList, formComponent: null, detailComponent: ActsDetail, RouteName: 'Actas', allowedRoles: ['DOCENTE','INVITADO','ESTUDIANTE','SECRETARIO', 'ADMINISTRADOR'] },
   { basePath: 'attendance', listComponent: AttendanceList, formComponent: AttendanceForm, RouteName: 'Asistencia', allowedRoles: ['MODERADOR', 'ADMINISTRADOR'] },
   { basePath: 'descriptions', listComponent: DescriptionList, formComponent: DescriptionForm, RouteName: 'Descripciones', allowedRoles: ['ADMINISTRADOR'] },
-  { basePath: 'task-assignments', listComponent: TaskAssignmentsList, formComponent: TaskAssignmentsForm, RouteName: 'Asignaciones de Tareas', allowedRoles: ['MODERADOR'] },
-  { basePath: 'session-order', listComponent: SessionOrderList, formComponent: SessionOrderForm, RouteName: 'Orden de Sesión', allowedRoles: ['MODERADOR'] },
+  { basePath: 'task-assignments', listComponent: TaskAssignmentsList, formComponent: TaskAssignmentsForm, RouteName: 'Asignaciones de Tareas', allowedRoles: ['INVITADO','ADMINISTRADOR'] },
+  { basePath: 'session-order', listComponent: SessionOrderList, formComponent: SessionOrderForm, RouteName: 'Orden de Sesión', allowedRoles: ['INVITADO','ESTUDIANTE','ADMINISTRADOR'] },
 ];
 
 


### PR DESCRIPTION
This pull request updates the access control for various routes in the `src/router/protectedRoutes.ts` file. The changes primarily involve modifying the `allowedRoles` for different routes to include additional roles.

Changes to access control:

* Updated `allowedRoles` for the `tasks` route to include `ESTUDIANTE`.
* Expanded `allowedRoles` for the `requests` route to include `DOCENTE`, `INVITADO`, and `ESTUDIANTE`.
* Modified `allowedRoles` for the `sessions` route to include `DOCENTE`, `MODERADOR`, `INVITADO`, and `ESTUDIANTE`.
* Changed `allowedRoles` for the `members` route to include `MODERADOR`.
* Updated `allowedRoles` for the `applicants` route to include `ADMINISTRADOR`.
* Added `ADMINISTRADOR` to the `allowedRoles` for the `propositions` route.
* Expanded `allowedRoles` for the `acts` route to include `DOCENTE`, `INVITADO`, and `ESTUDIANTE`.
* Modified `allowedRoles`